### PR TITLE
Update player.c to flush the audio file.

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -513,6 +513,11 @@ void *BarPlayerThread (void *data) {
 
 	/* If the song was played all the way through tag it. */
 	if (wRet == WAITRESS_RET_OK) {
+		int rc = fflush(player->fly.audio_file);
+		if (rc) {
+			BarUiMsg (player->settings, MSG_ERR, "Failed to flush audio file: %s\n",
+				player->fly.audio_file_path);
+        	}
 		BarFlyTag(&player->fly, player->settings);
 	}
 


### PR DESCRIPTION
Add an fflush before tagging. This avoids the "partial file" messages on playback that are shown in issue #479.
